### PR TITLE
:fix:本番環境のデータベースにuserが登録されない問題対応

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,5 +65,6 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
 config.hosts << ENV['NGROK_URL']
+config.hosts << ENV['HEROKU_URL']
 
 end


### PR DESCRIPTION
auth0のpost user registrationで本番環境のデーたんベースにもユーザーを登録する機能を実装したがブロックされ登録できなかったので、config.hostsの記述でリクエストを通すように修正