### PR TITLE
:update:mainブランチ時にruby.ymlが発火しないよう修正

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,9 @@
 name: Ruby CI
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - "main"
 
 jobs:
   rubocop:


### PR DESCRIPTION
ruby.ymlは開発ブランチにpush時に既に発火するのでmainにマージ時にも発火すると重複してしまう為